### PR TITLE
Don't throw undefined index error when chrome returns ECONNREFUSED

### DIFF
--- a/src/Exceptions/Node/HandlesNodeErrors.php
+++ b/src/Exceptions/Node/HandlesNodeErrors.php
@@ -28,7 +28,7 @@ trait HandlesNodeErrors
     {
         $error = is_string($error) ? json_decode($error, true) : $error;
 
-        $this->originalTrace = $error['stack'];
+        $this->originalTrace = $error['stack'] ?? '';
 
         $message = $error['message'];
 


### PR DESCRIPTION
Added a check whenever stack is missing from rialto error object.
This happens when using puphpeteer package

An example error which triggers the undefined index exception:
```json
{  
   "error":{  
      "__rialto_error__":true,
      "message":"connect ECONNREFUSED 127.0.0.1:42461"
   }
}
```