### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/ImplementationTest.php
+++ b/tests/ImplementationTest.php
@@ -14,7 +14,7 @@ class ImplementationTest extends TestCase
 {
     const JS_FUNCTION_CREATE_DEPRECATION_PATTERN = '/^Nesk\\\\Rialto\\\\Data\\\\JsFunction::create\(\)/';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -24,7 +24,7 @@ class ImplementationTest extends TestCase
         $this->fs = $this->canPopulateProperty('fs') ? new FsWithProcessDelegation : null;
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->fs = null;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,7 @@ class TestCase extends BaseTestCase
 {
     private $dontPopulateProperties = [];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
According to the [official PHP doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.