### PR TITLE
Add support for symfony/process 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         "php": ">=7.1",
         "clue/socket-raw": "^1.2",
         "psr/log": "^1.0",
-        "symfony/process": "^3.3|^4.0|^5.0"
+        "symfony/process": "^3.3|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "monolog/monolog": "^1.23",
-        "phpunit/phpunit": "^6.5|^7.0"
+        "phpunit/phpunit": "^6.5|^7.0|^8.0"
     },
     "suggest": {
         "ext-weakref": "Required to run all the tests"


### PR DESCRIPTION
This PR bumps the composer dependencies to support the latest `symfony/process` package (which is a downstream dependency of Laravel 9). Since `symfony/process` requires PHP 8, I also had to bump PHPUnit and update some deprecated tests. 

The following tests returned as "risky" and I'm not entirely sure how to fix them:

```
There were 3 risky tests:

1) Nesk\Rialto\Tests\ImplementationTest::forbidden_options_are_removed
This test did not perform any assertions

/Users/aryeh/Code/Packages/rialto/tests/ImplementationTest.php:369

2) Nesk\Rialto\Tests\ImplementationTest::logger_is_used_when_provided
This test did not perform any assertions

/Users/aryeh/Code/Packages/rialto/tests/ImplementationTest.php:464

3) Nesk\Rialto\Tests\ImplementationTest::node_console_calls_are_logged
This test did not perform any assertions
```

Thank you greatly for this great package (we use PuPHPeteer extensively), and please let me know if there are any questions  or feedback!